### PR TITLE
adjust required ruby version to allow 2.2.2p95

### DIFF
--- a/aws_memfix.gemspec
+++ b/aws_memfix.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^bin/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = [">= 2.2.0", "<= 2.2.2"]
+  spec.required_ruby_version = [">= 2.2.0", "< 2.2.3"]
 
   spec.add_dependency "aws-sdk", "~> 2.0"
 


### PR DESCRIPTION
The last ruby 2.2.2 release I installed reports as 2.2.2p95, which doesn't allow aws_memfix to install when `required_ruby_version <= 2.2.2`.

I'm going to go and raise this as an issue with Rubygems too, for for the sake of stdlib rubygems users, it'd be great to get this merged in...
